### PR TITLE
Add analytics as an external dependency

### DIFF
--- a/src/canopy-webpack-config.js
+++ b/src/canopy-webpack-config.js
@@ -95,6 +95,7 @@ module.exports = function(name, overridesConfig) {
         /^single-spa-canopy$/,
         /^single-spa$/,
         /^sofe$/,
+        /^cp-analytics$/,
       ],
     };
 


### PR DESCRIPTION
`cp-analytics` is not a part of common-dependencies so it should be external