### PR TITLE
changing the config to have devserver stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,12 @@ Finally, create the following `scripts` in your package.json:
   "scripts": {
     "build": "webpack --config webpack.config.js --env.analyze=static",
     "analyze": "webpack --config webpack.config.js --env.analyze=server",
-    "start": "webpack-dev-server --config ./webpack.config.js --https --disable-host-check --cert ~/.canopy-ssl/public.pem --key ~/.canopy-ssl/key.pem --port"
+    "start": "webpack-dev-server --port"
   }
 }
 ```
+
+You'll need to add SSL certificates to `~/.canopy-ssl/`, or define your own directory by changing the start script above to `webpack-dev-server --cert {location} --key {location} --port`
 
 Now add `yarn build` to your `.gitlab-ci.yml` file for the build step. You can run `yarn analyze` at any time to see your bundle size and breakdown. And `yarn start`
 will start up a web server that is ready to go as a sofe override.
@@ -73,6 +75,7 @@ canopy-webpack-config assumes a few things about your project and provides defau
 - It compiles your library to AMD format
 - It compiles your code into the `build` directory relative to where you started the webpack process.
 - It excludes all [common dependencies](git@code.canopy.ninja:front-end/gold/common-dependencies.git) from the build.
+- Requires webpack-dev-server >= 3.4.0
 
 ## Limitations
 the webpack config for canopy-webpack-config will always create the output bundle in the directory that the webpack process was started in. This

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Finally, create the following `scripts` in your package.json:
 }
 ```
 
-You'll need to add SSL certificates to `~/.canopy-ssl/`, or define your own directory by changing the start script above to `webpack-dev-server --cert {location} --key {location} --port`
+You'll need to add SSL certificates to `~/.canopy-ssl/`, or define your own by changing the start script above to `webpack-dev-server --cert {location} --key {location} --port`
 
 Now add `yarn build` to your `.gitlab-ci.yml` file for the build step. You can run `yarn analyze` at any time to see your bundle size and breakdown. And `yarn start`
 will start up a web server that is ready to go as a sofe override.

--- a/src/canopy-webpack-config.js
+++ b/src/canopy-webpack-config.js
@@ -10,6 +10,12 @@ if (process.argv.some(arg => arg.includes('webpack-dev-server'))) {
   isDevServer = true
 }
 
+const hostIndex = process.argv.findIndex(arg => arg === "--host")
+const host = hostIndex >= 0 && process.argv[hostIndex + 1] ? process.argv[hostIndex + 1] : "0.0.0.0"
+
+const portIndex = process.argv.findIndex(arg => arg === "--port")
+const port = portIndex >= 0 && process.argv[portIndex + 1] ? process.argv[portIndex + 1] : "8080"
+
 module.exports = function(name, overridesConfig) {
   if (typeof name !== 'string') {
     throw new Error('canopy-webpack-config expects a string name as the first argument')
@@ -97,6 +103,16 @@ module.exports = function(name, overridesConfig) {
         /^sofe$/,
         /^cp-analytics$/,
       ],
+      devServer: {
+        host: host,
+        https: {
+          cert: fs.readFileSync(`${homedir}/.canopy-ssl/public.pem`),
+          key: fs.readFileSync(`${homedir}/.canopy-ssl/key.pem`)
+        },
+        disableHostCheck: true,
+        sockHost: host,
+        sockPort: port,
+      }
     };
 
     overridesConfig = typeof overridesConfig === 'function' ? overridesConfig(env) : overridesConfig


### PR DESCRIPTION
makes devserver websockets work (so things like refresh on save work again). removes the need for each project to have all the devserver options.

technically would be a breaking change, since it now requires a minimum version of webpack dev server.