### PR TITLE
removing named modules and using the webpack-jsonp to keep each codes…

### DIFF
--- a/src/canopy-webpack-config.js
+++ b/src/canopy-webpack-config.js
@@ -36,7 +36,7 @@ module.exports = function(name, overridesConfig) {
       entry: `./src/${name}.js`,
       output: {
         filename: `${name}.js`,
-        library: name,
+        jsonpFunction: "wpjsonp-"+name,
         libraryTarget: 'amd',
         path: path.resolve(process.cwd(), 'build'),
         chunkFilename: '[name].js',


### PR DESCRIPTION
...codesplit independent.

named modules aren't the way going forward -- for example, native es modules aren't named, they're just based on the url. SystemJS recommends to not use named modules as well.