### PR TITLE
Update CODEOWNERS to frontend-icc team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @CanopyTax/frontend-leads
+* @CanopyTax/frontend-icc


### PR DESCRIPTION
This PR updates the CODEOWNERS file to change the code ownership from @CanopyTax/frontend-leads to @CanopyTax/frontend-icc team.

## Changes
- Updated CODEOWNERS file to replace `@CanopyTax/frontend-leads` with `@CanopyTax/frontend-icc`