### PR TITLE
Add 7-day minimum release age gate

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -4,4 +4,15 @@ enableGlobalCache: false
 
 nodeLinker: node-modules
 
+npmMinimalAgeGate: 7d
+
+npmPreapprovedPackages:
+  - "@canopytax/*"
+  - "browserslist-config-canopy"
+  - "canopy-webpack-config"
+  - "eslint-config-canopy"
+  - "kremling"
+  - "single-spa"
+  - "single-spa-canopy"
+
 yarnPath: .yarn/releases/yarn-4.10.3.cjs


### PR DESCRIPTION
## Summary
- Adds `npmMinimalAgeGate: 7d` to `.yarnrc.yml` so newly published versions of third-party packages must be at least 7 days old before they can be installed — a defense against npm supply-chain attacks
- Exempts our own packages (`@canopytax/*`, `single-spa`, `single-spa-canopy`, `kremling`, `eslint-config-canopy`, `browserslist-config-canopy`, `canopy-webpack-config`) via `npmPreapprovedPackages`
- No Yarn version bump needed — already on 4.10.3

## Why
Following the recent wave of npm supply-chain attacks (Shai-Hulud, the `nx` compromise, etc.), the 7-day gate gives the community time to detect and respond to a compromised package before our installs pick it up. The escape hatch is `YARN_NPM_MINIMAL_AGE_GATE=0 yarn add ...` when a fast install is genuinely needed.

Part of a coordinated rollout across all ~60 Canopy FE repos.

## Test plan
- [x] `yarn install` exit 0
- [ ] No lint/test scripts in this repo to run